### PR TITLE
Skip CI on draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     - main
     - development
     # optional section, "ready_for_review" means it will not run on draft PRs
+    # see this page for all pull_request activity "types" options: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request 
     types:
     - opened
     - reopened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches:
     - main
     - development
+    # optional section, "ready_for_review" means it will not run on draft PRs
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - ready_for_review
+
 
 jobs:
   tox:


### PR DESCRIPTION
This shows how to skip the CI run on draft PRs, useful if using paid runners with long-running CI. 
