### PR TITLE
add code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: coverage
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    - development
+  pull_request:
+    branches:
+    - main
+    - development
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Install packages needed for tests and coverage
+        run: pip install pytest pytest-cov
+      
+      - name: Run tests and create coverage report
+        run: |
+          pytest --cov-report=xml --cov-report=term tests/
+          coverage xml
+
+      # upload coverage to codecov, only if this is a push to main
+      - name: Upload coverage to codecov if push to main
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Run tests and create coverage report
         run: |
           pytest --cov-report=xml --cov-report=term tests/
-          coverage xml
 
       # upload coverage to codecov, only if this is a push to main
       - name: Upload coverage to codecov if push to main

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,9 +31,7 @@ jobs:
         run: |
           pytest --cov-report=xml --cov-report=term tests/
 
-      # upload coverage to codecov, only if this is a push to main
-      - name: Upload coverage to codecov if push to main
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      - name: Upload coverage to codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![LOGO](CCN-logo-wText.png)
 
 
-[![ci-ccn-template](https://github.com/flatironinstitute/ccn-template/actions/workflows/ci.yml/badge.svg)](https://github.com/flatironinstitute/ccn-template/actions/workflows/main.yml) [![codecov](https://codecov.io/github/magland/ccn-template/graph/badge.svg?token=YR0AB4C7TS)](https://codecov.io/github/magland/ccn-template)
+[![ci-ccn-template](https://github.com/flatironinstitute/ccn-template/actions/workflows/ci.yml/badge.svg)](https://github.com/flatironinstitute/ccn-template/actions/workflows/main.yml) [![codecov](https://codecov.io/github/flatironinstitute/ccn-template/graph/badge.svg?token=IRAYDW81ER)](https://codecov.io/github/flatironinstitute/ccn-template)
 
 # ccn-template
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ![LOGO](CCN-logo-wText.png)
 
 
-[![ci-ccn-template](https://github.com/flatironinstitute/ccn-template/actions/workflows/ci.yml/badge.svg)](https://github.com/flatironinstitute/ccn-template/actions/workflows/main.yml)
+[![ci-ccn-template](https://github.com/flatironinstitute/ccn-template/actions/workflows/ci.yml/badge.svg)](https://github.com/flatironinstitute/ccn-template/actions/workflows/main.yml) [![codecov](https://codecov.io/github/magland/ccn-template/graph/badge.svg?token=YR0AB4C7TS)](https://codecov.io/github/magland/ccn-template)
+
 # ccn-template
 
 Template repository for CCN software projects

--- a/docs/notes/06-ci.md
+++ b/docs/notes/06-ci.md
@@ -23,4 +23,65 @@
   ```
   - trigger the [connect.yml](https://github.com/flatironinstitute/ccn-template/blob/main/.github/workflows/connect.yml) github action for debuging, it will allow you to ssh connect to the runner
   - deploy to `pypi` on release (test using `test.pypi.org`, test installation and tests run, then deploy)
-  
+
+## Code coverage
+
+Code coverage refers to the measurement of how much of a codebase is tested by automated tests. Ideally, all code should be tested so that any changes can be verified to not break anything. In practice, this is not always possible, but it is still a good idea to aim for high coverage.
+
+To collect coverage locally, run the following command at the root of the project
+
+```bash
+pytest --cov-report=xml --cov-report=term tests/
+```
+
+This will run the tests, write a coverage summary to the terminal, and generate a `coverage.xml report`. This `.xml` file can be uploaded to [codecov.io](https://codecov.io) (a free service for open source public projects) to generate an online report and coverage badge for the main README.md. Ut can also be utilized by editors like VSCode to show coverage in the editor.
+
+To configure GitHub actions to automatically run coverage and upload the results to codecov.io, add something like the following to `.github/workflows/coverage.yml`:
+
+```yaml
+name: coverage
+on:
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+    - development
+  pull_request:
+    branches:
+    - main
+    - development
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+
+      - name: Install packages needed for tests and coverage
+        run: pip install pytest pytest-cov
+      
+      - name: Run tests and create coverage report
+        run: |
+          pytest --cov-report=xml --cov-report=term tests/
+
+      # upload coverage to codecov, only if this is a push to main
+      - name: Upload coverage to codecov if push to main
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          flags: unittests
+```
+
+You will need to set the `CODECOV_TOKEN` secret in the repository settings on GitHub. This can be obtained from codecov.io. Follow the [instructions here](https://docs.codecov.com/docs/quick-start) for information on how to do this.
+
+Once the above GitHub workflow has run successfully, you can add a [coverage status badge](https://docs.codecov.com/docs/status-badges) to your main README.md file. This will show visitors the current coverage level of the project.

--- a/docs/notes/06-ci.md
+++ b/docs/notes/06-ci.md
@@ -72,9 +72,7 @@ jobs:
         run: |
           pytest --cov-report=xml --cov-report=term tests/
 
-      # upload coverage to codecov, only if this is a push to main
-      - name: Upload coverage to codecov if push to main
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
* adds code coverage gh action that generates a coverage report and uploads to codecov.io
* adds codecov badge (see below)
* adds a blurb about coverage in the note about ci (06-ci.md)

Right now the badge points to my fork of ccn-template. Obviously that will need to be updated once the main repo is registered on codecov.io.